### PR TITLE
Add reusable pipelines

### DIFF
--- a/pragmatic/api.py
+++ b/pragmatic/api.py
@@ -2,18 +2,23 @@ from pragmatic.pipelines.indexing import LocalFileIndexingPipelineWrapper
 from pragmatic.pipelines.rag import RagPipelineWrapper
 from pragmatic.pipelines.utils import produce_custom_settings
 
-
-def index_path_for_rag(path, **kwargs):
+def create_index_pipeline(path, **kwargs):
     settings = produce_custom_settings(kwargs)
-    pipeline = LocalFileIndexingPipelineWrapper(settings, path)
-    pipeline.build_pipeline()
-    return pipeline.run()
+    index_pipeline = LocalFileIndexingPipelineWrapper(settings, path)
+    index_pipeline.build_pipeline()
+    return index_pipeline
 
-def execute_rag_query(query, **kwargs):
+def create_rag_pipeline(**kwargs):
     settings = produce_custom_settings(kwargs)
-    pipeline = RagPipelineWrapper(settings, query)
-    pipeline.build_pipeline()
-    return pipeline.run()
+    rag_pipeline = RagPipelineWrapper(settings)
+    rag_pipeline.build_pipeline()
+    return rag_pipeline
+
+def indexing_for_rag(index_pipeline, **kwargs):
+    return index_pipeline.run()
+
+def execute_rag_query(rag_pipeline, query, **kwargs):
+    return rag_pipeline.run(query)
 
 def evaluate_rag_pipeline(**kwargs):
     from pragmatic.pipelines.evaluation import Evaluator
@@ -23,7 +28,9 @@ def evaluate_rag_pipeline(**kwargs):
     return evaluator.evaluate_rag_pipeline()
 
 
-__all__ = ["index_path_for_rag",
+__all__ = ["create_index_pipeline",
+           "create_rag_pipeline",
+           "indexing_for_rag",
            "execute_rag_query",
            # "evaluate_rag_pipeline"
-           ]
+        ]

--- a/pragmatic/pipelines/pipeline.py
+++ b/pragmatic/pipelines/pipeline.py
@@ -50,9 +50,12 @@ class PipelineWrapper(object):
     def _set_last_connect_point(self, connect_point):
         self.__last_connect_point = connect_point
 
-    def run(self):
-        logger.debug(f"Executing the pipeline with the following arguments:\n{self._args}")
-        return self._pipeline.run(self._args)
+    def run(self, pipeline_args_dict=None):
+        if pipeline_args_dict:
+            logger.debug(f"Executing the pipeline with the following arguments:\n{pipeline_args_dict}")
+            return self._pipeline.run(pipeline_args_dict)
+        else:
+            return self._pipeline.run(self._args)
 
     def build_pipeline(self):
         raise NotImplementedError()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sentence-transformers>=3.0.0
 docling>=2.9.0
 milvus_haystack==0.0.11
 docling_haystack==0.1.1
+pymilvus>=2.4.2

--- a/test/sanity_test.py
+++ b/test/sanity_test.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath(os.getcwd()))
 
 from docling.document_converter import DocumentConverter
 
-from pragmatic import index_path_for_rag, execute_rag_query
+from pragmatic import create_index_pipeline, create_rag_pipeline, indexing_for_rag, execute_rag_query
 
 SOURCE_PDF_URLS = [
     "https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.12/pdf/cli_tools/Red_Hat_build_of_MicroShift-4.12-CLI_tools-en-US.pdf",
@@ -52,39 +52,37 @@ def main():
     docling_convert(SOURCE_PDF_URLS)
 
     # index the JSONs under a Milvus Lite instance
-    print("Step 2: Embedding the JSONs and indexing them into Milvus vector database \n")
-    index_path_for_rag(DOCS_LOCAL_DIR_NAME,
-                       milvus_deployment_type="lite",
+    print("Step 2: Initialize an indexing pipeline \n")
+    index_pipeline = create_index_pipeline(DOCS_LOCAL_DIR_NAME,milvus_deployment_type="lite",
                        milvus_file_path="./milvus.db",
                        embedding_model_path="sentence-transformers/all-MiniLM-L12-v2",
                        input_document_formats=['pdf'] if TEST_PDF_TO_JSON_CONVERSION else ['json'])
+    
+    print("Step 3: Indexing documents into Milvus vector database using the index pipeline created \n")
+    indexing_for_rag(index_pipeline)
 
     # execute a simple RAG query
-    print("Step 3: Executing simple RAG queries \n")
-    print("Question: How to install OpenShift CLI on macOS?")
-    result1 = execute_rag_query("How to install OpenShift CLI on macOS?",
-                               milvus_file_path="./milvus.db",
+    print("Step 3: Initialize a RAG pipeline \n")
+    rag_pipeline = create_rag_pipeline(milvus_file_path="./milvus.db",
                                embedding_model_path="sentence-transformers/all-MiniLM-L12-v2",
-                               llm_base_url="http://vllm-service:8000/v1",
+                               llm_base_url="https://vllm-inference-predictor-mixture-of-experts-bots--runtime-int.apps.stc-ai-e1-pp.imap.p1.openshiftapps.com/v1",
+                               llm="/mnt/models/",
                                top_k=3)
+    # To run the pipeline in eval mode
+    #rag_pipeline.set_evaluation_mode(True)
+    print("Step 4: Executing a query using the RAG pipeline \n")
+    print("Question: How to install OpenShift CLI on macOS?")
+    result1 = execute_rag_query(rag_pipeline, "How to install OpenShift CLI on macOS?")
     print("Response generated:")
     print(f"\n{result1}")
     print("\n")
     print("Question: What are the two deployment options in OpenShift AI?")
-    result2 = execute_rag_query("What are the two deployment options in OpenShift AI?",
-                               milvus_file_path="./milvus.db",
-                               embedding_model_path="sentence-transformers/all-MiniLM-L12-v2",
-                               llm_base_url="http://vllm-service:8000/v1",
-                               top_k=3)
+    result2 = execute_rag_query(rag_pipeline, "What are the two deployment options in OpenShift AI?")
     print("Response generated:")
     print(f"\n{result2}")
     print("\n")
     print("Question: What is OpenShift AI?")
-    result3 = execute_rag_query("What is OpenShift AI?",
-                               milvus_file_path="./milvus.db",
-                               embedding_model_path="sentence-transformers/all-MiniLM-L12-v2",
-                               llm_base_url="http://vllm-service:8000/v1",
-                               top_k=3)
+    result3 = execute_rag_query(rag_pipeline, "What is OpenShift AI?")
     print("Response generated:")
     print(f"\n{result3}")
 


### PR DESCRIPTION
(Addresses #28)

This PR allows to build a reusable indexing and RAG pipeline.

**Main Changes:**

- Updated `rag.py` to allow the `run()` function to execute the pipeline with required component arguments
- Updated `pipeline.py` to allow the component arguments to be passed as a dictionary for the RAG pipeline
- Updated `api.py` to introduce separate functions for building and executing the index/RAG pipelines
- Updated `test/sanity_test.py` to demonstrate these changes

**Testing the Code**
- You can run `test/sanity_test.py` to test all the new implemented changes

