### PR TITLE
convert main.py into installable CLI tool pragmatic

### DIFF
--- a/bin/pragmatic
+++ b/bin/pragmatic
@@ -1,3 +1,4 @@
+# !/bin/python3
 # addressing the issue where the project structure causes pragmatic to not be on the path
 import sys
 import os
@@ -5,8 +6,8 @@ sys.path.insert(0, os.path.abspath(os.getcwd()))
 
 import argparse
 
-from api import index_path_for_rag, execute_rag_query, evaluate_rag_pipeline
-from settings import DEFAULT_SETTINGS
+from pragmatic.api import index_path_for_rag, execute_rag_query, evaluate_rag_pipeline
+from pragmatic.settings import DEFAULT_SETTINGS
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/redhat-et/PRAGmatic'
+    scripts=["bin/pragmatic"],
 )


### PR DESCRIPTION
I want to run pragmatic inside of a container, via Podman.

We need to be able to execute the pragmatic command in order to populate the database via the ramalama rag command.

ramalama rag /tmp/mydoc.pdf https://my.web/docs.docx ~/mydocsdir quay.io/ramalama/ragdata:latest

 podman run -ti --rm --network none -v /tmp/mydoc.pdf:/tmp/mydoc.pdf:ro ~/mydocsdir:~/mydocsdir:ro -v /home/dwalsh/ramalama:/tmp/output quay.io/ramalama/ramalama-docling  /usr/bin/pragmatic ...